### PR TITLE
Add exit arg

### DIFF
--- a/rwci/client.py
+++ b/rwci/client.py
@@ -30,7 +30,7 @@ class Client:
       self.ws = await websockets.client.connect(self.gateway_url)
     except Exception as e:
       log.warn(e.__class__.__name__ + ": " + str(e))
-      sys.exit()
+      sys.exit(1)
 
   def event(self, coro):
     if not asyncio.iscoroutinefunction(coro):


### PR DESCRIPTION
`sys.exit()` defaults to 0 and means "successful termination". In this case, connection failed and should terminate thusly. Added a 1 for a basic abnormal termination.

Source: https://docs.python.org/3/library/sys.html#sys.exit